### PR TITLE
v0.6 - use new "public" keyword of appmonitor API

### DIFF
--- a/php-class/appmonitorapi.class.php.md
+++ b/php-class/appmonitorapi.class.php.md
@@ -28,7 +28,7 @@
  * SERVICING, REPAIR OR CORRECTION.<br>
  * <br>
  * --------------------------------------------------------------------------------<br>
- * @version v0.4
+ * @version v0.6
  * @author Axel Hahn
  * @link https://github.com/iml-it/appmonitor-api-client
  * @license GPL
@@ -36,8 +36,10 @@
  * --------------------------------------------------------------------------------<br>
  * 2024-11-14  0.1  axel.hahn@unibe.ch  first lines
  * 2024-11-15  0.2  axel.hahn@unibe.ch  update hmac authorization header; add verifications in setConfig(); configure ttl and cachedir
- * 2024-11-20  0.3  axel.hahn@unibe.ch  handle full data or metadate only; add 3 functions to get parts of the app result
+ * 2024-11-20  0.3  axel.hahn@unibe.ch  handle full data or metadata only; add 3 functions to get parts of the app result
  * 2024-11-20  0.4  axel.hahn@unibe.ch  add getAllApps, getAllTags, getGroupResult
+ * 2025-02-19  0.5  axel.hahn@unibe.ch  reduce curl timeout 15 -> 5 sec
+ * 2025-03-12  0.6  axel.hahn@unibe.ch  handle newly added "public" keyword of api, add method getAppResultSince()
  */
 ```
 
@@ -57,8 +59,7 @@ Constructor
 
 | Parameter | Type | Description
 |--         |--    |--
-| \<optional\> array $aConfig = [] | `array` | configuration array with subkeys                        - apiurl                        - user                        - secret
-
+| \<optional\> $aConfig | `array` | configuration array with subkeys                        - apiurl                        - user                        - secret
 
 ### 🔹 public fetchByTags()
 
@@ -70,9 +71,8 @@ Get application data of all matching apps by given list of tags@see getErrors()
 
 | Parameter | Type | Description
 |--         |--    |--
-| \<optional\> array $aTags = [] | `array` | 
-| \<optional\> bool $bFull = false | `bool` | 
-
+| \<optional\> $aTags | `array` | array of tags to collect matching applications
+| \<optional\> $sWhat | `string` | kind of details; one of "public" (default) | "all" | "meta" | "checks"
 
 ### 🔹 public fetchData()
 
@@ -86,8 +86,7 @@ Then, all received data is looped over to extract metadata perapplication, which
 
 | Parameter | Type | Description
 |--         |--    |--
-| \<required\> array $aRelUrls | `array` | array of relative urls to fetch
-
+| \<required\> $aRelUrls | `array` | array of relative urls to fetch
 
 ### 🔹 public getAllApps()
 
@@ -117,8 +116,7 @@ Get an array of checks and their results by a given app id.Get an array of app m
 
 | Parameter | Type | Description
 |--         |--    |--
-| \<required\> string $sApp | `string` | App ID
-
+| \<required\> $sApp | `string` | App ID
 
 ### 🔹 public getAppData()
 
@@ -130,8 +128,7 @@ Get an array of all fetched app data by a given app id.You need to get the list 
 
 | Parameter | Type | Description
 |--         |--    |--
-| \<required\> string $sApp | `string` | App ID
-
+| \<required\> $sApp | `string` | App ID
 
 ### 🔹 public getAppMeta()
 
@@ -143,8 +140,7 @@ Get an array of app meta data by a given app id.You need to get the list of all 
 
 | Parameter | Type | Description
 |--         |--    |--
-| \<required\> string $sApp | `string` | App ID
-
+| \<required\> $sApp | `string` | App ID
 
 ### 🔹 public getAppResult()
 
@@ -156,8 +152,19 @@ Get an array of result meta infos by a given app id.This information is availabl
 
 | Parameter | Type | Description
 |--         |--    |--
-| \<required\> string $sApp | `string` | App ID
+| \<required\> $sApp | `string` | App ID
 
+### 🔹 public getAppResultSince()
+
+Get unix timestamp when the current appstatus was reached.It returns -1 if not found.@see getApps()@see getAppResult()
+
+**Return**: `int`
+
+**Parameters**: **1**
+
+| Parameter | Type | Description
+|--         |--    |--
+| \<required\> $sApp | `string` | App ID
 
 ### 🔹 public getApps()
 
@@ -196,10 +203,7 @@ Set configuration.Given values will be verified. It throws an exception if somet
 
 | Parameter | Type | Description
 |--         |--    |--
-| \<required\> array $aConfig | `array` | configuration array with subkeys                        - apiurl    string  url of appmonitor api, eg http://localhost/api/v1                        - user      string  username for basic auth or hmac hash                        - secret    string  (for hmac hash)                        - password  string  (for basic auth)                        - ttl       int     time to live in seconds (0 = no caching; max. 60)                        - cachedir  string  path to cache dir
-
-
-
+| \<required\> $aConfig | `array` | configuration array with subkeys                        - apiurl    string  url of appmonitor api, eg http://localhost/api/v1                        - user      string  username for basic auth or hmac hash                        - secret    string  (for hmac hash)                        - password  string  (for basic auth)                        - ttl       int     time to live in seconds (0 = no caching; max. 60)                        - cachedir  string  path to cache dir
 
 ---
 Generated with Axels PHP class doc parser.

--- a/php-example/config.php.dist
+++ b/php-example/config.php.dist
@@ -16,12 +16,10 @@ return [
         [
             'label'=>'Live systems (Demo)',
             'tags'=>['live'],
-            'full'=>false,
         ],
         [
             'label'=>'Monitoring (Demo)',
             'tags'=>['monitoring'],
-            'full'=>false,
         ],
     ],
 

--- a/php-example/index.php
+++ b/php-example/index.php
@@ -69,16 +69,17 @@ function renderApp_lines(array $aAppdata): string
     global $aReturncodes;
     $sReturn='';
 
-    $iResult=$aAppdata['result'];
+    $iResult=$aAppdata['meta']['result'];
     $sResult=$aReturncodes[$iResult] ?? '??';
-    $sHost=$aAppdata['host'];
-    $sAppname=$aAppdata['website'];
-
+    $sHost=$aAppdata['meta']['host'];
+    $sAppname=$aAppdata['meta']['website'];
+    $sSince="since ".date("Y-m-d H:i", $aAppdata['since']);
     return "<div class=\"app result-$iResult\">
 
         <span class=\"resultlabel\">$sResult</span>
-        <strong>$sAppname</strong>
-        ($sHost)
+        <span class=\"appname\">$sAppname</span>
+        <span class=\"host\">$sHost</span>
+        <span class=\"since\">$sSince</span>
 
     </div>\n\n";
 }
@@ -106,7 +107,7 @@ $api = new appmonitorapi($aConfig['appmonitor']);
 // ----- Loop over group emtries
 foreach($aConfig['groups'] as $aGroup )
 {
-    $api->fetchByTags($aGroup['tags'], $aGroup['full']);
+    $api->fetchByTags($aGroup['tags']);
 
     // --- check errors
     if ( count($api->getErrors()) > 0 ) {
@@ -130,7 +131,7 @@ foreach($aConfig['groups'] as $aGroup )
     $sOutGroup='';
     foreach($api->getApps() as $sAppId)
     {
-        $aAppdata=$api->getAppMeta($sAppId);
+        $aAppdata=$api->getAppData($sAppId);
         $sOutGroup.=''
             // for debugging remove next comment
             // .'<pre>'.print_r($aAppdata, 1).'</pre>'
@@ -154,9 +155,12 @@ if($bShowErrorDetails)
     foreach($aReturncodes as $returncode => $sLabel)
     {
         $sOut.= renderApp_lines([
-            'website' => "Test website",
-            'host' => "srv-$returncode",
-            'result' => $returncode,
+            'meta' => [
+                'website' => "Test website",
+                'host' => "srv-$returncode",
+                'result' => $returncode,                    
+            ],
+            'since' => time(),
         ]);
     }
 }

--- a/php-example/main.css
+++ b/php-example/main.css
@@ -57,7 +57,7 @@ main {
     margin-bottom: 0.2em;
 }
 
-.resultlabel{
+.app .resultlabel{
     border-radius: 0.5em 0 0 0.5em;
     display: inline-block;
     width: 5em;
@@ -65,6 +65,24 @@ main {
     margin-right: 1em;
     padding: 0.5em;
 }
+.app .appname{
+    display: inline-block;
+    font-weight: bold;
+    width: 20em;
+    margin-right: 1em;
+    padding: 0.5em;
+}
+.app .host{
+    display: inline-block;
+    width: 20em;
+    margin-right: 1em;
+    padding: 0.5em;
+}
+
+.app .since{
+    display: inline-block;
+}
+
 
 /* ---------- result codes ---------- */
 


### PR DESCRIPTION
In the IML appmonitors api a request with "public" keyword returns the application status added by a timestamp since when the app is in this state.

file appmonitorapi.class.php:

ADDED:

* method `getAppResultSince()`

MODIFIED:

* 2nd param in `fetchByTags()` was bool ... now  a string for kind of details; one of "public" (default) | "all" | "meta" | "checks"